### PR TITLE
fix(builder): Fix authentication client throwing error instead of returning on expected Error

### DIFF
--- a/apps/builder/features/Builder/components/InputConfigurators/OptionTargetInput/OptionTargetInput.tsx
+++ b/apps/builder/features/Builder/components/InputConfigurators/OptionTargetInput/OptionTargetInput.tsx
@@ -14,14 +14,14 @@ import * as React from "react";
 import { Edge, Input as InputType } from "@open-decision/type-classes";
 import { DragHandle } from "./DragHandle";
 import { Reorder, useDragControls } from "framer-motion";
-import {
-  useConditionsOfNode,
-  useEdgesOfNode,
-  useNode,
-} from "../../../../features/Builder/state/treeStore/hooks";
-import { useTreeContext } from "../../../../features/Builder/state/treeStore/TreeContext";
-import { useNotificationStore } from "../../../../features/Notifications/NotificationState";
 import { Crosshair2Icon, PlusIcon, TrashIcon } from "@radix-ui/react-icons";
+import { useNotificationStore } from "../../../../Notifications/NotificationState";
+import {
+  useEdgesOfNode,
+  useConditionsOfNode,
+  useNode,
+} from "../../../state/treeStore/hooks";
+import { useTreeContext } from "../../../state/treeStore/TreeContext";
 
 const StyledReorderGroup = styled(Reorder.Group, {
   listStyle: "none",

--- a/apps/builder/features/Builder/components/NodeEditingSidebar/NodeEditingSidebar.tsx
+++ b/apps/builder/features/Builder/components/NodeEditingSidebar/NodeEditingSidebar.tsx
@@ -7,7 +7,6 @@ import {
   Row,
   Form,
 } from "@open-decision/design-system";
-import { OptionTargetInputs } from "../../../../features/Builder/components/OptionTargetInput/OptionTargetInput";
 import * as React from "react";
 import { Node } from "@open-decision/type-classes";
 import { nodeNameMaxLength } from "../../utilities/constants";
@@ -23,6 +22,7 @@ import { useTreeContext } from "../../state/treeStore/TreeContext";
 import { AnimatePresence, motion } from "framer-motion";
 import { ParentNodeSelector } from "./ParentNodeSelector";
 import { StartNodeLabel } from "../NodeLabels/StartNodeLabels";
+import { OptionTargetInputs } from "../InputConfigurators/OptionTargetInput/OptionTargetInput";
 
 const styledMotionDiv = css({
   position: "relative",

--- a/packages/api-helpers/src/fetch.ts
+++ b/packages/api-helpers/src/fetch.ts
@@ -1,13 +1,15 @@
 import { z } from "zod";
-import { APIError } from "@open-decision/type-classes";
+import { APIError, ODError } from "@open-decision/type-classes";
 
-async function getResponseData(response: Response): Promise<unknown> {
+async function getResponseData<TData>(
+  response: Response
+): Promise<TData | APIError> {
   let data;
   const contentType = response.headers.get("content-type");
   if (contentType?.includes("application/json")) data = await response.json();
 
   if (response.status >= 400) {
-    throw new APIError(data);
+    return new APIError(data);
   }
 
   return data;
@@ -27,10 +29,24 @@ export const safeFetch = async <TValidation extends z.ZodTypeAny>(
     body: body ? body : undefined,
     ...options,
   });
+  try {
+    const response = await fetch(request);
 
-  const response = fetch(request);
+    let data;
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("application/json")) data = await response.json();
 
-  const responseData = await getResponseData(await response);
+    if (response.status >= 400) {
+      return new APIError(data);
+    }
 
-  return validation ? validation.parse(responseData) : responseData;
+    return validation ? validation.parse(data) : data;
+  } catch (error) {
+    if (error instanceof Error) throw error;
+
+    throw new ODError({
+      code: "UNEXPECTED_ERROR",
+      message: "Something unexpected happened when fetching from the API.",
+    });
+  }
 };

--- a/packages/type-classes/src/Error/ErrorCodes.ts
+++ b/packages/type-classes/src/Error/ErrorCodes.ts
@@ -1,4 +1,4 @@
-export type CommonErrors = "GENERIC_ERROR";
+export type CommonErrors = "GENERIC_ERROR" | "UNEXPECTED_ERROR";
 
 export type ProgrammerErrors =
   | "MISSING_CONTEXT_PROVIDER"

--- a/packages/type-classes/src/Error/ODError.ts
+++ b/packages/type-classes/src/Error/ODError.ts
@@ -3,13 +3,13 @@ import { ErrorCodes, ProgrammerErrors } from "./ErrorCodes";
 
 export type ODErrorConstructorParameters = {
   code: ErrorCodes;
-  additionalData?: {};
+  additionalData?: Record<string, unknown>;
 } & Omit<Error, "name">;
 
 export class ODError extends Error {
   readonly code: ErrorCodes;
   readonly timestamp?: number;
-  readonly additionalData?: {};
+  readonly additionalData?: Record<string, unknown>;
 
   constructor({ code, additionalData, message }: ODErrorConstructorParameters) {
     super(message);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "declaration": false,
+    "useUnknownInCatchVariables": true,
     "rootDir": ".",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
- throwing an error resulted in the catch block triggering
- since the error is untyped in the catch block it should not have been
  directly assigned to the error on the state machine which should
  be a string
- this lead to react crashing, because the error class that actually got
  returned can not be rendered as a child