### PR TITLE
fix(design-system): Revert extraction of textSizes from textStyles

### DIFF
--- a/packages/design-system/src/Form/ErrorMessage.tsx
+++ b/packages/design-system/src/Form/ErrorMessage.tsx
@@ -1,8 +1,8 @@
 import { Box } from "../Box";
 import { styled } from "../stitches";
-import { textSizeVariant, textStyles } from "../Text";
+import { textStyles } from "../Text";
 
-export const ErrorMessage = styled(Box, textSizeVariant, textStyles, {
+export const ErrorMessage = styled(Box, textStyles, {
   color: "$danger11",
   backgroundColor: "$danger1",
   borderRadius: "$md",

--- a/packages/design-system/src/Form/Label.tsx
+++ b/packages/design-system/src/Form/Label.tsx
@@ -1,6 +1,6 @@
 import { styled, css } from "../stitches";
 import { disabledSelector } from "../stitches/stateSelectors";
-import { textSizeVariant } from "../Text";
+import { textStyles } from "../Text";
 
 export const labelStyles = css({
   display: "inline-flex",
@@ -14,4 +14,4 @@ export const labelStyles = css({
 });
 
 export type LabelProps = React.ComponentProps<typeof Label>;
-export const Label = styled("label", textSizeVariant, labelStyles);
+export const Label = styled("label", labelStyles, textStyles);

--- a/packages/design-system/src/Link/Link.tsx
+++ b/packages/design-system/src/Link/Link.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { styled, css } from "../stitches";
 import { intentSelector } from "../stitches/stateSelectors";
-import { textSizeVariant } from "../Text";
+import { textStyles } from "../Text";
 
 export type LinkProps = React.ComponentProps<typeof Link>;
 
@@ -16,4 +16,4 @@ export const linkStyles = css({
   [`${intentSelector}`]: { textDecoration: "underline" },
 });
 
-export const Link = styled("a", textSizeVariant, linkStyles);
+export const Link = styled("a", linkStyles, textStyles);

--- a/packages/design-system/src/Text/index.tsx
+++ b/packages/design-system/src/Text/index.tsx
@@ -6,12 +6,6 @@ export const textStyles = css({
   colorFallback: "$colorScheme-text",
   margin: "unset",
 
-  defaultVariants: {
-    size: "medium",
-  },
-});
-
-export const textSizeVariant = css({
   variants: {
     size: {
       large: { textStyle: "large-text" },
@@ -26,4 +20,4 @@ export const textSizeVariant = css({
   },
 });
 
-export const Text = styled("p", textSizeVariant, textStyles);
+export const Text = styled("p", textStyles);


### PR DESCRIPTION
- components that should follow the textStyles should use the entire textStyles class

fixes #171 