### PR TITLE
fix(interpreter): Fix interpreter not resolving correctly

### DIFF
--- a/apps/builder/features/Dashboard/TreeImport.tsx
+++ b/apps/builder/features/Dashboard/TreeImport.tsx
@@ -27,15 +27,17 @@ export const TreeImport = React.forwardRef<
   const OD = useOD();
 
   const { mutate: createTree } = useMutation(
-    (name: string) => OD.trees.create({ body: { name } }),
+    [importedData],
+    ({ name, ..._ }: { name: string; data: Tree.TTree }) =>
+      OD.trees.create({ body: { name } }),
     {
-      onSuccess: ({ uuid }) => {
-        if (!importedData) return;
+      onSuccess: ({ uuid }, { data }) => {
+        if (!data) return;
 
         const yDoc = new Y.Doc();
         const yMap = yDoc.getMap("tree");
         new IndexeddbPersistence(uuid, yDoc);
-        const importStore = proxy(importedData);
+        const importStore = proxy(data);
         bindProxyAndYMap(importStore, yMap);
 
         queryClient.invalidateQueries(useTreesQueryKey);
@@ -72,7 +74,7 @@ export const TreeImport = React.forwardRef<
 
           setImportedData(data);
 
-          return createTree(name);
+          return createTree({ name, data });
         };
 
         fileReader.readAsText(event.currentTarget.files?.[0]);

--- a/apps/builder/features/Dashboard/TreeImport.tsx
+++ b/apps/builder/features/Dashboard/TreeImport.tsx
@@ -19,15 +19,11 @@ export const TreeImport = React.forwardRef<
   HTMLLabelElement,
   Omit<FileInputProps, "children"> & { onDone?: () => void }
 >(function TreeImport({ onDone, ...props }, ref) {
-  const [importedData, setImportedData] = React.useState<
-    Tree.TTree | undefined
-  >();
   const { addNotification } = useNotificationStore();
 
   const OD = useOD();
 
   const { mutate: createTree } = useMutation(
-    [importedData],
     ({ name, ..._ }: { name: string; data: Tree.TTree }) =>
       OD.trees.create({ body: { name } }),
     {
@@ -71,8 +67,6 @@ export const TreeImport = React.forwardRef<
           }
 
           const { name, ...data } = validatedResult.data;
-
-          setImportedData(data);
 
           return createTree({ name, data });
         };

--- a/packages/interpreter-react/src/useInterpreter.tsx
+++ b/packages/interpreter-react/src/useInterpreter.tsx
@@ -47,7 +47,11 @@ export function InterpreterProvider({
 }: InterpreterProviderProps) {
   const interpreterMachine = useInterpreterMachine(tree, options);
 
-  const service = useInterpret(interpreterMachine, config, onChange);
+  const service = useInterpret(
+    interpreterMachine,
+    { ...config, devTools: true },
+    onChange
+  );
 
   return (
     <InterpreterContext.Provider value={{ service, tree }}>

--- a/packages/interpreter/src/interpreter.ts
+++ b/packages/interpreter/src/interpreter.ts
@@ -42,7 +42,6 @@ const resolveConditions =
     for (const conditionId in conditions) {
       const condition = conditions[conditionId];
       const existingAnswerId = context.answers[condition.inputId];
-      console.log(condition.answerId);
 
       if (condition.answerId === existingAnswerId) {
         const edge = Object.values<Edge.TEdge>(tree.edges ?? {}).find(

--- a/packages/interpreter/src/interpreter.ts
+++ b/packages/interpreter/src/interpreter.ts
@@ -42,6 +42,7 @@ const resolveConditions =
     for (const conditionId in conditions) {
       const condition = conditions[conditionId];
       const existingAnswerId = context.answers[condition.inputId];
+      console.log(condition.answerId);
 
       if (condition.answerId === existingAnswerId) {
         const edge = Object.values<Edge.TEdge>(tree.edges ?? {}).find(
@@ -161,6 +162,7 @@ export const createInterpreterMachine = (
       actions: {
         assignAnswerToContext: assign((context, event) => ({
           answers: { ...context.answers, [event.inputId]: event.answerId },
+          history: { ...context.history, position: 0 },
         })),
         resetToInitialContext: assign((_context, _event) => ({
           history: { nodes: [tree.startNode], position: 0 },


### PR DESCRIPTION
It turned out the history position was not reset when going back and then entering a new answer. This resulted in a previous node being displayed. See example:

![Untitled-2022-07-04-0937](https://user-images.githubusercontent.com/38015558/177105751-b619578a-fa44-47d9-b7eb-99c7caf57b56.png)

This also addresses #191 which was the result of stale tree data.