### PR TITLE
fix(builder): Fix jumpy input

### DIFF
--- a/.github/workflows/deploy-prs.yml
+++ b/.github/workflows/deploy-prs.yml
@@ -90,10 +90,10 @@ jobs:
         run: flyctl deploy --config ${{env.CONFIG}} --app ${{env.APP_NAME}} --region ${{env.FLY_REGION}} --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} --strategy immediate
       - name: Create DB
         continue-on-error: true
-        run: flyctl postgres create --name ${{env.DB_NAME}} --region ${{env.FLY_REGION}}
+        run: flyctl postgres create --name ${{env.DB_NAME}} --region ${{env.FLY_REGION}} --yes
       - name: Attach database
         continue-on-error: true
-        run: flyctl postgres attach ${{env.DB_NAME}} --app ${{env.APP_NAME}}
+        run: flyctl postgres attach ${{env.DB_NAME}} --app ${{env.APP_NAME}} --yes
       - name: Sentry Release
         uses: getsentry/action-release@v1.2.0
         env:

--- a/.github/workflows/deploy-prs.yml
+++ b/.github/workflows/deploy-prs.yml
@@ -88,12 +88,9 @@ jobs:
       - name: Deploy
         id: deploy
         run: flyctl deploy --config ${{env.CONFIG}} --app ${{env.APP_NAME}} --region ${{env.FLY_REGION}} --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} --strategy immediate
-      - name: Create DB
-        continue-on-error: true
-        run: flyctl postgres create --name ${{env.DB_NAME}} --region ${{env.FLY_REGION}} --yes
       - name: Attach database
         continue-on-error: true
-        run: flyctl postgres attach ${{env.DB_NAME}} --app ${{env.APP_NAME}} --yes
+        run: flyctl postgres attach od-preview-db --app ${{env.APP_NAME}}
       - name: Sentry Release
         uses: getsentry/action-release@v1.2.0
         env:

--- a/apps/builder/features/Builder/components/NodeEditingSidebar/NodeEditingSidebar.tsx
+++ b/apps/builder/features/Builder/components/NodeEditingSidebar/NodeEditingSidebar.tsx
@@ -11,7 +11,6 @@ import { Node } from "@open-decision/type-classes";
 import { nodeNameMaxLength } from "../../utilities/constants";
 import { NodeMenu } from "../Canvas/Nodes/NodeMenu";
 import {
-  useInputs,
   useParents,
   useSelectedNodes,
   useStartNodeId,
@@ -81,7 +80,6 @@ type Props = { node: Pick<Node.TNode, "id" | "data">; css?: StyleObject };
 
 function NodeEditingSidebarContent({ node, css }: Props) {
   const t = useTranslations("builder.nodeEditingSidebar");
-  const inputs = useInputs(node.data.inputs);
   const { updateNodeContent } = useTreeContext();
 
   return (
@@ -120,8 +118,12 @@ function NodeEditingSidebarContent({ node, css }: Props) {
         />
       </Box>
       <Box as="section">
-        {Object.values(inputs).map((input) => (
-          <OptionTargetInputs nodeId={node.id} input={input} key={input.id} />
+        {Object.values(node.data.inputs).map((inputId) => (
+          <OptionTargetInputs
+            nodeId={node.id}
+            inputId={inputId}
+            key={inputId}
+          />
         ))}
       </Box>
     </Stack>


### PR DESCRIPTION
- changing the answer in the input resulted in the entire sidebar being rerendered
- the OptionTargetInput is now directly getting its data so the sidebar does not have to rerender when the inputs content changes
- the onChange handler on the input was recreated on every render
- this caused the input to be rerendered every time which reset the cursor position to the end of the input
- the onChange handler is now memoized to prevent this