### PR TITLE
feat(api): Add new preview route for tree data

### DIFF
--- a/apps/api/src/routes/v1/tree.route.ts
+++ b/apps/api/src/routes/v1/tree.route.ts
@@ -2,7 +2,8 @@ import {
   publishedTreesOfTreesCollection,
   treesCollection,
   treesSingle,
-  treesDataSingle,
+  treeDataSingle,
+  treePreview,
 } from "@open-decision/tree-api-specification";
 import express from "express";
 import { treeController } from "../../controllers/tree.controller";
@@ -21,8 +22,10 @@ treeRouter
   .delete(auth(), treeController.deleteDecisionTree);
 
 treeRouter
-  .route(treesDataSingle(":uuid"))
-  .get(treeController.getCurrentTreeData);
+  .route(treeDataSingle(":uuid"))
+  .get(auth(), treeController.getCurrentTreeData);
+
+treeRouter.route(treePreview(":uuid")).get(treeController.getTreePreview);
 
 treeRouter
   .route(publishedTreesOfTreesCollection(":treeUuid"))

--- a/apps/builder/features/Data/useTreeAPI.ts
+++ b/apps/builder/features/Data/useTreeAPI.ts
@@ -15,7 +15,12 @@ import {
   TGetTreeDataOutput,
   TGetTreePreviewOutput,
 } from "@open-decision/tree-api-specification";
-import { APIError, ODError, Tree } from "@open-decision/type-classes";
+import {
+  APIError,
+  isAPIError,
+  ODError,
+  Tree,
+} from "@open-decision/type-classes";
 import {
   useMutation,
   UseMutationOptions,
@@ -146,7 +151,15 @@ export const useTreeAPI = () => {
     return useQuery(
       treeDataQueryKey(uuid),
       () => OD.trees.data.getPreview({ params: { uuid } }),
-      options
+      {
+        ...options,
+        retry: (failureCount, error) => {
+          if (isAPIError(error) && error.code === "PREVIEW_NOT_ENABLED") {
+            return false;
+          }
+          return failureCount < 3;
+        },
+      }
     );
   };
 

--- a/apps/builder/features/Data/useTreeAPI.ts
+++ b/apps/builder/features/Data/useTreeAPI.ts
@@ -13,6 +13,7 @@ import {
   TCreatePublishedTreeOutput,
   TDeletePublishedTreeOutput,
   TGetTreeDataOutput,
+  TGetTreePreviewOutput,
 } from "@open-decision/tree-api-specification";
 import { APIError, ODError, Tree } from "@open-decision/type-classes";
 import {
@@ -130,6 +131,21 @@ export const useTreeAPI = () => {
     return useQuery(
       treeDataQueryKey(uuid),
       () => OD.trees.data.get({ params: { uuid } }),
+      options
+    );
+  };
+
+  const useTreePreview = <TData = FetchReturn<TGetTreePreviewOutput>>(
+    uuid: string,
+    options?: {
+      staleTime?: number;
+      select?: (data: FetchReturn<Tree.TTree>) => TData;
+      enabled?: boolean;
+    }
+  ) => {
+    return useQuery(
+      treeDataQueryKey(uuid),
+      () => OD.trees.data.getPreview({ params: { uuid } }),
       options
     );
   };
@@ -439,5 +455,6 @@ export const useTreeAPI = () => {
     useUnPublish,
     useImport,
     useExport,
+    useTreePreview,
   };
 };

--- a/apps/builder/middleware.ts
+++ b/apps/builder/middleware.ts
@@ -56,5 +56,5 @@ export const middleware: NextMiddleware = async (request) => {
 
 // See "Matching Paths" below to learn more
 export const config = {
-  matcher: ["/settings", "/", "/builder/:path"],
+  matcher: ["/settings", "/", "/builder/:path?"],
 };

--- a/apps/builder/middleware.ts
+++ b/apps/builder/middleware.ts
@@ -56,5 +56,5 @@ export const middleware: NextMiddleware = async (request) => {
 
 // See "Matching Paths" below to learn more
 export const config = {
-  matcher: ["/settings", "/", "/builder/:path*"],
+  matcher: ["/settings", "/", "/builder/:path"],
 };

--- a/apps/builder/pages/builder/[id]/preview.tsx
+++ b/apps/builder/pages/builder/[id]/preview.tsx
@@ -5,7 +5,6 @@ import { GetServerSideProps } from "next";
 import { Renderer } from "@open-decision/renderer";
 import { useTranslations } from "next-intl";
 import { useTreeAPI } from "../../../features/Data/useTreeAPI";
-import { APIError } from "@open-decision/type-classes";
 
 export const getServerSideProps: GetServerSideProps<
   any,
@@ -41,24 +40,12 @@ type PageProps = { treeId: string };
 export default function VorschauPage({ treeId }: PageProps) {
   const t = useTranslations("renderer.preview");
 
-  const { data: hasPreview, error: previewEnabledError } =
-    useTreeAPI().useTreeQuery(treeId, {
-      select: (result) => {
-        if (!result.data.hasPreview)
-          throw new APIError({ code: "PREVIEW_NOT_ENABLED" });
-
-        return result.data.hasPreview;
-      },
-    });
-
   const { isLoading, isPaused, data, error, isSuccess } =
-    useTreeAPI().useTreeData(treeId, {
+    useTreeAPI().useTreePreview(treeId, {
       select: (result) => result.data,
       staleTime: Infinity,
-      enabled: hasPreview,
     });
 
-  if (previewEnabledError) throw previewEnabledError;
   if (isPaused || isLoading) return <LoadingSpinner />;
   if (!isSuccess) throw error;
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -13,6 +13,7 @@ import {
   getTree,
   getTrees,
   updateTree,
+  getTreePreview,
 } from "@open-decision/tree-api-specification";
 import {
   login,
@@ -48,6 +49,7 @@ export const client = (context: TContext) => {
       update: updateTree(context),
       data: {
         get: getTreeData(context),
+        getPreview: getTreePreview(context),
       },
       publishedTrees: {
         get: getPublishedTreesOfTree(context),

--- a/packages/tree-api-specification/src/routes/trees/index.ts
+++ b/packages/tree-api-specification/src/routes/trees/index.ts
@@ -4,4 +4,4 @@ export * from "./uuid/delete";
 export * from "./uuid/patch";
 export * from "./uuid/publishedTree";
 export * from "./uuid/get";
-export * from "./uuid/treeData/get";
+export * from "./uuid/treeData";

--- a/packages/tree-api-specification/src/routes/trees/uuid/treeData/get/query.ts
+++ b/packages/tree-api-specification/src/routes/trees/uuid/treeData/get/query.ts
@@ -1,12 +1,12 @@
 import { TContext, QueryConfig } from "@open-decision/api-helpers";
-import { treesDataSingle } from "../../../../../urls";
+import { treeDataSingle } from "../../../../../urls";
 import { TGetTreeDataInput } from "./input";
 import { getTreeDataOutput } from "./output";
 
 export const getTreeData =
   (context: TContext) =>
   async (inputs: TGetTreeDataInput, config?: QueryConfig) => {
-    let combinedUrl = treesDataSingle(inputs.params.uuid);
+    let combinedUrl = treeDataSingle(inputs.params.uuid);
     const prefix = config?.urlPrefix ?? context.urlPrefix;
 
     if (prefix) combinedUrl = prefix + combinedUrl;

--- a/packages/tree-api-specification/src/routes/trees/uuid/treeData/index.ts
+++ b/packages/tree-api-specification/src/routes/trees/uuid/treeData/index.ts
@@ -1,1 +1,2 @@
 export * from "./get";
+export * from "./preview/get";

--- a/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/index.ts
+++ b/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/index.ts
@@ -1,0 +1,3 @@
+export * from "./input";
+export * from "./output";
+export * from "./query";

--- a/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/input.ts
+++ b/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/input.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const getTreePreviewInput = z.object({
+  params: z.object({ uuid: z.string().uuid() }),
+});
+
+export type TGetTreePreviewInput = z.infer<typeof getTreePreviewInput>;

--- a/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/output.ts
+++ b/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/output.ts
@@ -1,0 +1,5 @@
+import { Tree } from "@open-decision/type-classes";
+
+export const getTreePreviewOutput = Tree.Type;
+
+export type TGetTreePreviewOutput = Tree.TTree;

--- a/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/query.ts
+++ b/packages/tree-api-specification/src/routes/trees/uuid/treeData/preview/get/query.ts
@@ -1,0 +1,18 @@
+import { TContext, QueryConfig } from "@open-decision/api-helpers";
+import { treePreview } from "../../../../../../urls";
+import { TGetTreePreviewInput } from "./input";
+import { getTreePreviewOutput } from "./output";
+
+export const getTreePreview =
+  (context: TContext) =>
+  async (inputs: TGetTreePreviewInput, config?: QueryConfig) => {
+    let combinedUrl = treePreview(inputs.params.uuid);
+    const prefix = config?.urlPrefix ?? context.urlPrefix;
+
+    if (prefix) combinedUrl = prefix + combinedUrl;
+    return await context.fetchFunction(
+      combinedUrl,
+      { cache: "no-cache" },
+      { validation: getTreePreviewOutput }
+    );
+  };

--- a/packages/tree-api-specification/src/urls.ts
+++ b/packages/tree-api-specification/src/urls.ts
@@ -3,8 +3,11 @@ export const treesCollection = "/trees";
 export const treesSingle = (treeUuid: string) =>
   `${treesCollection}/${treeUuid}`;
 
-export const treesDataSingle = (treeUuid: string) =>
+export const treeDataSingle = (treeUuid: string) =>
   `${treesSingle(treeUuid)}/data`;
+
+export const treePreview = (treeUuid: string) =>
+  `${treesSingle(treeUuid)}/preview`;
 
 export const publishedTreesCollection = "/publishedTrees";
 export const publishedTreesSingle = (publishedTreesUuid: string) =>


### PR DESCRIPTION
- instead of having an unauthenticated route for all tree data we only want this behavior if hasPreview is true
- to have both options; get the treeData behind authentication and have a preview route the routes have been split