### PR TITLE
fix(builder): Fix error on selected node delete

### DIFF
--- a/apps/builder/features/Builder/components/InputConfigurators/OptionTargetInput/OptionTargetInput.tsx
+++ b/apps/builder/features/Builder/components/InputConfigurators/OptionTargetInput/OptionTargetInput.tsx
@@ -42,7 +42,7 @@ export function OptionTargetInputs({ nodeId, inputId }: SingleSelectProps) {
   const input = useInput(inputId);
   const ref = React.useRef<HTMLDivElement | null>(null);
 
-  if (!input) throw new Error("Input not found");
+  if (!input) return null;
 
   return (
     <>


### PR DESCRIPTION
- the error was caused by the OptionTargetInput throwing when no input was found
- this behavior was clashing with the exit animation of the sidebar that keeps the OptionTargetInput mounted for a short time after the node has been deleted
- the result was the error being thrown
- the fix is to just return null from the OptionTargetInput if the input cannot be found instead of throwing